### PR TITLE
Fix json decode bug: remove br from Accept-Encoding

### DIFF
--- a/investpy/screener.py
+++ b/investpy/screener.py
@@ -37,7 +37,7 @@ def screener(params, n_results=None, as_dataframe=True):
         "User-Agent": random_user_agent(),
         "X-Requested-With": "XMLHttpRequest",
         "Accept": "text/html",
-        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
     }
 


### PR DESCRIPTION
I received JSONDecode error while trying to use this PR to investpy

I tried the code from the original [issue](https://github.com/alvarobartt/investpy/issues/160)
```
midCapUS = investpy.ScreenerParams() \
.with_country("United States") \
.add_filter("Market Cap", 200e6, 1e9) \
.add_filter("Price to Sales (TTM)", 0, 10) \
.add_filter("P/E Ratio (TTM)", 0, 40) \
.add_filter("EPS(TTM) vs TTM 1 Yr. Ago", 0, 1e9)

results = investpy.screener(midCapUS, as_dataframe=True, n_results=100)
```

and received
```
JSONDecodeError                           Traceback (most recent call last)
<ipython-input-3-28ac00fb8e21> in <module>
      6 .add_filter("EPS(TTM) vs TTM 1 Yr. Ago", 0, 1e9)
      7 
----> 8 results = investpy.screener(midCapUS, as_dataframe=True, n_results=100)

~/.local/lib/python3.8/site-packages/investpy/screener.py in screener(params, n_results, as_dataframe)
     48         raise ConnectionError("ERR#0015: error " + str(req.status_code) + ", try again later.")
     49 
---> 50     data = req.json()
     51 
     52     if n_results is None:

~/.local/lib/python3.8/site-packages/requests/models.py in json(self, **kwargs)
    908                     # used.
    909                     pass
--> 910         return complexjson.loads(self.text, **kwargs)
    911 
    912     @property

/usr/lib/python3.8/json/__init__.py in loads(s, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
    355             parse_int is None and parse_float is None and
    356             parse_constant is None and object_pairs_hook is None and not kw):
--> 357         return _default_decoder.decode(s)
    358     if cls is None:
    359         cls = JSONDecoder

/usr/lib/python3.8/json/decoder.py in decode(self, s, _w)
    335 
    336         """
--> 337         obj, end = self.raw_decode(s, idx=_w(s, 0).end())
    338         end = _w(s, end).end()
    339         if end != len(s):

/usr/lib/python3.8/json/decoder.py in raw_decode(self, s, idx)
    353             obj, end = self.scan_once(s, idx)
    354         except StopIteration as err:
--> 355             raise JSONDecodeError("Expecting value", s, err.value) from None
    356         return obj, end

JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

After a few hours of traffic analysis I understood that `br` option in Accept-Encoding in POST header to investing.com is causing the trouble, so I removed it and it worked

The PR is only about the removing 4 characters :)